### PR TITLE
feat: add See Source Answers view

### DIFF
--- a/lib/home/bloc/home_bloc.dart
+++ b/lib/home/bloc/home_bloc.dart
@@ -14,6 +14,7 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
     on<AskQuestion>(_onQuestion);
     on<QueryUpdated>(_queryUpdated);
     on<QuestionAsked>(_questionAsked);
+    on<SeeSourceAnswersRequested>(_onSeeSourceAnswersRequested);
   }
 
   final QuestionsRepository _questionsRepository;
@@ -48,5 +49,12 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         vertexResponse: result,
       ),
     );
+  }
+
+  void _onSeeSourceAnswersRequested(
+    SeeSourceAnswersRequested event,
+    Emitter<HomeState> emit,
+  ) {
+    emit(state.copyWith(status: Status.seeSourceAnswers));
   }
 }

--- a/lib/home/bloc/home_event.dart
+++ b/lib/home/bloc/home_event.dart
@@ -26,3 +26,7 @@ class QueryUpdated extends HomeEvent {
 class QuestionAsked extends HomeEvent {
   const QuestionAsked();
 }
+
+class SeeSourceAnswersRequested extends HomeEvent {
+  const SeeSourceAnswersRequested();
+}

--- a/lib/home/bloc/home_state.dart
+++ b/lib/home/bloc/home_state.dart
@@ -8,6 +8,7 @@ enum Status {
   thinking,
   thinkingToResults,
   results,
+  seeSourceAnswers,
 }
 
 class HomeState extends Equatable {
@@ -29,6 +30,7 @@ class HomeState extends Equatable {
       status == Status.askQuestionToThinking || status == Status.thinking;
   bool get isResultsVisible =>
       status == Status.thinkingToResults || status == Status.results;
+  bool get isSeeSourceAnswersVisible => status == Status.seeSourceAnswers;
   bool get isDashVisible => [
         Status.welcome,
         Status.welcomeToAskQuestion,

--- a/lib/home/view/home_page.dart
+++ b/lib/home/view/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:dash_ai_search/home/home.dart';
+import 'package:dash_ai_search/home/widgets/see_source_answers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:questions_repository/questions_repository.dart';
@@ -34,21 +35,22 @@ class HomeView extends StatelessWidget {
               bottom: 0,
               child: Background(),
             ),
-          const Positioned(
-            top: 40,
-            left: 48,
-            child: Logo(),
-          ),
           if (state.isWelcomeVisible) const WelcomeView(),
           if (state.isQuestionVisible) const QuestionView(),
           if (state.isThinkingVisible) const ThinkingView(),
           if (state.isResultsVisible) const ResultsView(),
+          if (state.isSeeSourceAnswersVisible) const SeeSourceAnswers(),
           if (state.isDashVisible)
             const Positioned(
               bottom: 50,
               left: 50,
               child: DashAnimation(),
             ),
+          Positioned(
+            top: 40,
+            left: 48,
+            child: Logo(hasDarkBackground: state.isSeeSourceAnswersVisible),
+          ),
         ],
       ),
     );

--- a/lib/home/widgets/logo.dart
+++ b/lib/home/widgets/logo.dart
@@ -3,19 +3,23 @@ import 'package:dash_ai_search/l10n/l10n.dart';
 import 'package:flutter/material.dart';
 
 class Logo extends StatelessWidget {
-  const Logo({super.key});
+  const Logo({super.key, this.hasDarkBackground = true});
+
+  final bool hasDarkBackground;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final l10n = context.l10n;
+    final textColor =
+        hasDarkBackground ? VertexColors.arctic : VertexColors.navy;
 
     return Row(
       children: [
         Text(
           l10n.vertexAI,
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: VertexColors.navy,
+            color: textColor,
           ),
         ),
         const SizedBox(width: 4),
@@ -24,7 +28,7 @@ class Logo extends StatelessWidget {
         Text(
           l10n.flutter,
           style: theme.textTheme.bodyLarge?.copyWith(
-            color: VertexColors.navy,
+            color: textColor,
           ),
         ),
       ],

--- a/lib/home/widgets/results_view.dart
+++ b/lib/home/widgets/results_view.dart
@@ -58,71 +58,6 @@ class BlueContainer extends StatelessWidget {
   }
 }
 
-class FeedbackButtons extends StatelessWidget {
-  @visibleForTesting
-  const FeedbackButtons({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Row(
-      children: [
-        Like(),
-        SizedBox(
-          width: 16,
-        ),
-        Dislike(),
-      ],
-    );
-  }
-}
-
-class Like extends StatelessWidget {
-  @visibleForTesting
-  const Like({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return FeedbackButton(
-      icon: vertexImages.thumbUp.image(),
-    );
-  }
-}
-
-class Dislike extends StatelessWidget {
-  @visibleForTesting
-  const Dislike({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return FeedbackButton(
-      icon: vertexImages.thumbDown.image(),
-    );
-  }
-}
-
-class FeedbackButton extends StatelessWidget {
-  const FeedbackButton({
-    required this.icon,
-    this.onPressed,
-    super.key,
-  });
-
-  final Widget icon;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return CircleAvatar(
-      backgroundColor: VertexColors.white,
-      radius: 32,
-      child: InkWell(
-        onTap: onPressed,
-        child: SizedBox.square(dimension: 33, child: icon),
-      ),
-    );
-  }
-}
-
 class SeeSourceAnswersButton extends StatelessWidget {
   const SeeSourceAnswersButton({super.key});
 
@@ -134,6 +69,8 @@ class SeeSourceAnswersButton extends StatelessWidget {
       child: TertiaryCTA(
         label: l10n.seeSourceAnswers,
         icon: vertexIcons.arrowForward.image(),
+        onPressed: () =>
+            context.read<HomeBloc>().add(const SeeSourceAnswersRequested()),
       ),
     );
   }

--- a/lib/home/widgets/see_source_answers.dart
+++ b/lib/home/widgets/see_source_answers.dart
@@ -1,0 +1,83 @@
+import 'package:api_client/api_client.dart';
+import 'package:app_ui/app_ui.dart';
+import 'package:dash_ai_search/home/home.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SeeSourceAnswers extends StatelessWidget {
+  const SeeSourceAnswers({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final response =
+        context.select((HomeBloc bloc) => bloc.state.vertexResponse);
+    return SizedBox.expand(
+      child: ColoredBox(
+        color: VertexColors.googleBlue,
+        child: Column(
+          children: [
+            const SizedBox(height: 100),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 50),
+              child: Row(
+                children: [
+                  Expanded(child: _AiResponse(response.summary)),
+                  const SizedBox(width: 150),
+                  Expanded(child: _ResponseCarousel(response.documents)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AiResponse extends StatelessWidget {
+  const _AiResponse(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          text,
+          style: VertexTextStyles.body.copyWith(
+            color: VertexColors.white,
+            fontSize: 32,
+          ),
+        ),
+        const SizedBox(height: 20),
+        const FeedbackButtons(),
+      ],
+    );
+  }
+}
+
+class _ResponseCarousel extends StatelessWidget {
+  const _ResponseCarousel(this.documents);
+
+  final List<VertexDocument> documents;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        const Placeholder(color: VertexColors.flutterCyan),
+        Center(
+          child: Text(
+            '${documents.length}',
+            style: VertexTextStyles.body.copyWith(
+              color: VertexColors.flutterCyan,
+              fontSize: 60,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/packages/app_ui/lib/src/widgets/feedback_buttons.dart
+++ b/packages/app_ui/lib/src/widgets/feedback_buttons.dart
@@ -1,0 +1,83 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+
+/// {@template feedback_buttons}
+/// Like and dislike buttons. When the like button is pressed, the [onLike]
+/// callback will trigger, and when the dislike button is pressed, the
+/// [onDislike] will trigger.
+/// {@endtemplate}
+class FeedbackButtons extends StatelessWidget {
+  /// {@macro feedback_buttons}
+  const FeedbackButtons({
+    this.onLike,
+    this.onDislike,
+    super.key,
+  });
+
+  /// Callback that triggers when the like button is pressed
+  final VoidCallback? onLike;
+
+  /// Callback that triggers when the dislike button is pressed
+  final VoidCallback? onDislike;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _Like(onPressed: onLike),
+        const SizedBox(width: 16),
+        _Dislike(onPressed: onDislike),
+      ],
+    );
+  }
+}
+
+class _Like extends StatelessWidget {
+  const _Like({this.onPressed});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return _FeedbackButton(
+      icon: vertexImages.thumbUp.image(),
+      onPressed: onPressed,
+    );
+  }
+}
+
+class _Dislike extends StatelessWidget {
+  const _Dislike({this.onPressed});
+
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return _FeedbackButton(
+      icon: vertexImages.thumbDown.image(),
+      onPressed: onPressed,
+    );
+  }
+}
+
+class _FeedbackButton extends StatelessWidget {
+  const _FeedbackButton({
+    required this.icon,
+    this.onPressed,
+  });
+
+  final Widget icon;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return CircleAvatar(
+      backgroundColor: VertexColors.white,
+      radius: 32,
+      child: InkWell(
+        onTap: onPressed,
+        child: SizedBox.square(dimension: 33, child: icon),
+      ),
+    );
+  }
+}

--- a/packages/app_ui/lib/src/widgets/widgets.dart
+++ b/packages/app_ui/lib/src/widgets/widgets.dart
@@ -1,6 +1,7 @@
 export 'animated_sprite.dart';
 export 'app_animated_cross_fade.dart';
 export 'app_circular_progress_indicator.dart';
+export 'feedback_buttons.dart';
 export 'primary_cta.dart';
 export 'question_input_text_field.dart';
 export 'tertiary_cta.dart';

--- a/packages/app_ui/test/src/widgets/feedback_buttons_pressed_test.dart
+++ b/packages/app_ui/test/src/widgets/feedback_buttons_pressed_test.dart
@@ -1,0 +1,49 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FeedbackButtons', () {
+    testWidgets(
+      'triggers onLike when the like button is pressed',
+      (tester) async {
+        var wasPressed = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FeedbackButtons(
+                onLike: () {
+                  wasPressed = true;
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.image(vertexImages.thumbUp.image().image));
+        await tester.pumpAndSettle();
+        expect(wasPressed, isTrue);
+      },
+    );
+
+    testWidgets(
+      'triggers onDislike when the dislike button is pressed',
+      (tester) async {
+        var wasPressed = false;
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: FeedbackButtons(
+                onDislike: () {
+                  wasPressed = true;
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.tap(find.image(vertexImages.thumbDown.image().image));
+        await tester.pumpAndSettle();
+        expect(wasPressed, isTrue);
+      },
+    );
+  });
+}

--- a/test/home/bloc/home_bloc_test.dart
+++ b/test/home/bloc/home_bloc_test.dart
@@ -79,5 +79,16 @@ void main() {
         ],
       );
     });
+
+    group('SeeSourceAnswersRequested', () {
+      blocTest<HomeBloc, HomeState>(
+        'emits Status.seeSourceAnswers',
+        build: buildBloc,
+        act: (bloc) => bloc.add(SeeSourceAnswersRequested()),
+        expect: () => [
+          HomeState(status: Status.seeSourceAnswers),
+        ],
+      );
+    });
   });
 }

--- a/test/home/bloc/home_event_test.dart
+++ b/test/home/bloc/home_event_test.dart
@@ -30,5 +30,12 @@ void main() {
         equals(QuestionAsked()),
       );
     });
+
+    test('SeeSourceAnswersRequested supports value equality', () {
+      expect(
+        SeeSourceAnswersRequested(),
+        equals(SeeSourceAnswersRequested()),
+      );
+    });
   });
 }

--- a/test/home/view/home_page_test.dart
+++ b/test/home/view/home_page_test.dart
@@ -1,5 +1,6 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:dash_ai_search/home/home.dart';
+import 'package:dash_ai_search/home/widgets/see_source_answers.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -84,11 +85,43 @@ void main() {
       expect(find.byType(ThinkingView), findsOneWidget);
     });
 
-    testWidgets('renders ResultsView if isResultsVisible', (tester) async {
+    group('ResultsView', () {
+      testWidgets('is rendered if isResultsVisible', (tester) async {
+        when(() => homeBloc.state).thenReturn(
+          HomeState(
+            status: Status.results,
+          ),
+        );
+        await tester.pumpApp(
+          BlocProvider.value(
+            value: homeBloc,
+            child: HomeView(),
+          ),
+        );
+
+        expect(find.byType(ResultsView), findsOneWidget);
+      });
+
+      testWidgets('adds SeeSourceAnswersRequested to bloc', (tester) async {
+        when(() => homeBloc.state).thenReturn(
+          HomeState(status: Status.results),
+        );
+        await tester.pumpApp(
+          BlocProvider.value(
+            value: homeBloc,
+            child: HomeView(),
+          ),
+        );
+        expect(find.byType(SeeSourceAnswersButton), findsOneWidget);
+        await tester.tap(find.byType(SeeSourceAnswersButton));
+        verify(() => homeBloc.add(const SeeSourceAnswersRequested())).called(1);
+      });
+    });
+
+    testWidgets('renders SeeSourceAnswers if isSeeSourceAnswersVisible',
+        (tester) async {
       when(() => homeBloc.state).thenReturn(
-        HomeState(
-          status: Status.results,
-        ),
+        HomeState(status: Status.seeSourceAnswers),
       );
       await tester.pumpApp(
         BlocProvider.value(
@@ -97,7 +130,7 @@ void main() {
         ),
       );
 
-      expect(find.byType(ResultsView), findsOneWidget);
+      expect(find.byType(SeeSourceAnswers), findsOneWidget);
     });
   });
 }

--- a/test/home/widgets/see_source_answers_test.dart
+++ b/test/home/widgets/see_source_answers_test.dart
@@ -1,0 +1,52 @@
+import 'package:api_client/api_client.dart';
+import 'package:app_ui/app_ui.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dash_ai_search/home/home.dart';
+import 'package:dash_ai_search/home/widgets/see_source_answers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../helpers/helpers.dart';
+
+class _MockHomeBloc extends MockBloc<HomeEvent, HomeState>
+    implements HomeBloc {}
+
+void main() {
+  group('SeeSourceAnswers', () {
+    late HomeBloc homeBloc;
+    const response = VertexResponse(
+      summary: 'summary',
+      documents: [
+        VertexDocument(
+          metadata: VertexMetadata(
+            url: 'url',
+            title: 'title',
+            description: 'description',
+          ),
+        ),
+      ],
+    );
+
+    setUp(() {
+      homeBloc = _MockHomeBloc();
+      when(() => homeBloc.state).thenReturn(
+        HomeState(status: Status.seeSourceAnswers, vertexResponse: response),
+      );
+    });
+
+    testWidgets('renders the response', (tester) async {
+      await tester.pumpApp(
+        BlocProvider.value(
+          value: homeBloc,
+          child: Material(child: SeeSourceAnswers()),
+        ),
+      );
+      expect(find.text(response.summary), findsOneWidget);
+      expect(find.text(response.documents.length.toString()), findsOneWidget);
+      expect(find.byType(Placeholder), findsOneWidget);
+      expect(find.byType(FeedbackButtons), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Added very basic screen to see source answers, without animations nor fancy widgets. That would be next step.

A few refactors:

- Moved the logo to be the last item on the Stack, so it is always visible
- Moved the FeedbackButtons widget to the `app_ui`, so it can be reused. Even later on could be refactor inside the `app` folder to have the same reaction to `onLike` and `onDislike`.

https://github.com/VGVentures/dash_ai_search/assets/3237451/175161ae-6b90-4070-bac1-20f360e3ff30

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
